### PR TITLE
Call to SwarmUI for parsing before calling LLMs

### DIFF
--- a/Assets/magicprompt.js
+++ b/Assets/magicprompt.js
@@ -566,23 +566,10 @@ function wildcardSeedGenerator() {
       if (!generateBtn) return;
       const checkbox = document.getElementById('input_generatewildcardseed');
       if (!checkbox || !checkbox.checked) return;
-      const promptBox = document.getElementById('alt_prompt_textbox');
-      if (!promptBox) return;
-      const text = promptBox.value || '';
-      const regex = /(<param\[\s*wildcardseed\s*\]\s*:\s*)(-?\d+)(\s*>)/i;
-      if (!regex.test(text)) return;
-      const MAX_WC_SEED = 2147483647; // c# int.MaxValue
-      const newSeed = Math.floor(Math.random() * (MAX_WC_SEED + 1));
-      const newText = text.replace(regex, (m, pre, num, post) => `${pre}${newSeed}${post}`);
-      if (newText !== text) {
-        promptBox.value = newText;
-        if (typeof triggerChangeFor === 'function') {
-          triggerChangeFor(promptBox);
-        } else {
-          promptBox.dispatchEvent(new Event('input', { bubbles: true }));
-          promptBox.dispatchEvent(new Event('change', { bubbles: true }));
-        }
-      }
+      const MAX_WC_SEED = 4294967295;
+      let elem = getRequiredElementById('input_wildcardseed');
+      elem.value = Math.floor(Math.random() * (MAX_WC_SEED + 1));
+      triggerChangeFor(elem);
     }, true);
 }
 

--- a/Assets/magicprompt.js
+++ b/Assets/magicprompt.js
@@ -561,15 +561,24 @@ function addPromptButtons() {
 
 function wildcardSeedGenerator() {
     document.addEventListener('click', function (e) {
-      const target = e.target;
-      const generateBtn = target && (target.id === 'alt_generate_button' ? target : (target.closest ? target.closest('#alt_generate_button') : null));
-      if (!generateBtn) return;
-      const checkbox = document.getElementById('input_generatewildcardseed');
-      if (!checkbox || !checkbox.checked) return;
-      const MAX_WC_SEED = 4294967295;
-      let elem = getRequiredElementById('input_wildcardseed');
-      elem.value = Math.floor(Math.random() * (MAX_WC_SEED + 1));
-      triggerChangeFor(elem);
+        const MAX_WC_SEED = 4294967295;
+        const extensionEnabled = document.getElementById('input_group_content_magicprompt_toggle');
+        const generateEnabled = document.getElementById('input_mpgeneratewildcardseed');
+
+        if (
+            !e.target
+            || e.target.id !== 'alt_generate_button'
+            || !extensionEnabled
+            || !extensionEnabled.checked
+            || !generateEnabled
+            || !generateEnabled.checked
+        ) {
+            return;
+        }
+
+        let wildcardSeedElem = getRequiredElementById('input_wildcardseed');
+        wildcardSeedElem.value = Math.floor(Math.random() * MAX_WC_SEED);
+        triggerChangeFor(wildcardSeedElem);
     }, true);
 }
 

--- a/Assets/magicprompt.js
+++ b/Assets/magicprompt.js
@@ -559,6 +559,33 @@ function addPromptButtons() {
     altPromptRegion.insertBefore(container, altPromptRegion.firstChild);
 }
 
+function wildcardSeedGenerator() {
+    document.addEventListener('click', function (e) {
+      const target = e.target;
+      const generateBtn = target && (target.id === 'alt_generate_button' ? target : (target.closest ? target.closest('#alt_generate_button') : null));
+      if (!generateBtn) return;
+      const checkbox = document.getElementById('input_generatewildcardseed');
+      if (!checkbox || !checkbox.checked) return;
+      const promptBox = document.getElementById('alt_prompt_textbox');
+      if (!promptBox) return;
+      const text = promptBox.value || '';
+      const regex = /(<param\[\s*wildcardseed\s*\]\s*:\s*)(-?\d+)(\s*>)/i;
+      if (!regex.test(text)) return;
+      const MAX_WC_SEED = 2147483647; // c# int.MaxValue
+      const newSeed = Math.floor(Math.random() * (MAX_WC_SEED + 1));
+      const newText = text.replace(regex, (m, pre, num, post) => `${pre}${newSeed}${post}`);
+      if (newText !== text) {
+        promptBox.value = newText;
+        if (typeof triggerChangeFor === 'function') {
+          triggerChangeFor(promptBox);
+        } else {
+          promptBox.dispatchEvent(new Event('input', { bubbles: true }));
+          promptBox.dispatchEvent(new Event('change', { bubbles: true }));
+        }
+      }
+    }, true);
+}
+
 /**
  * Initializes on DOM load
  */
@@ -570,6 +597,8 @@ document.addEventListener("DOMContentLoaded", async function () {
         await loadSettings();
         // Add prompt buttons
         addPromptButtons();
+        // Setup auto wildcard seed generation on Generate click (capture phase, before onclick)
+        wildcardSeedGenerator();
         // Initialize modal
         $('#settingsModal').modal({
             backdrop: 'static', keyboard: false, show: false

--- a/MagicPromptExtension.cs
+++ b/MagicPromptExtension.cs
@@ -63,6 +63,13 @@ public class MagicPromptExtension : Extension
             Group: paramGroup,
             OrderPriority: 3
         ));
+        T2IParamTypes.Register<bool>(new T2IParamType(
+            Name: "Generate Wildcard Seed",
+            Description: "Every time you press Generate, a new Wildcard Seed is injected into the prompt. Requires having an existing param tag like `<param[wildcardseed]:1234>` in your prompt.",
+            Default: "false",
+            Group: paramGroup,
+            OrderPriority: 4
+        ));
 
         T2IParamInput.LateSpecialParameterHandlers.Add(userInput =>
         {

--- a/MagicPromptExtension.cs
+++ b/MagicPromptExtension.cs
@@ -41,7 +41,7 @@ public class MagicPromptExtension : Extension
 
     private static void AddT2IParameters()
     {
-        var paramGroup = new T2IParamGroup("Magic Prompt", Toggles: true, Open: false, IsAdvanced: false, OrderPriority: 9);
+        var paramGroup = new T2IParamGroup("Magic Prompt", Toggles: false, Open: false, IsAdvanced: false, OrderPriority: 9);
         _paramAutoEnable = T2IParamTypes.Register<bool>(new T2IParamType(
             Name: "Auto Enable",
             Description: "Automatically use Magic Prompt to rewrite your prompt before generation.",

--- a/MagicPromptExtension.cs
+++ b/MagicPromptExtension.cs
@@ -102,7 +102,14 @@ public class MagicPromptExtension : Extension
 
                 // No response from LLM, fallback to original prompt
                 if (string.IsNullOrEmpty(llmResponse)) return;
-                if (userInput.InternalSet.Get(_paramAppendOriginal))
+
+                // Remove the core text that was sent to the LLM from the original prompt, leaving only regional tags/parts
+                if (!userInput.InternalSet.Get(_paramAppendOriginal) && !string.IsNullOrWhiteSpace(promptRegions.GlobalPrompt))
+                {
+                    prompt = prompt?.Replace(promptRegions.GlobalPrompt, string.Empty);
+                }
+
+                if (!string.IsNullOrEmpty(prompt))
                 {
                     llmResponse = $"{llmResponse}\n{prompt}";
                 }

--- a/MagicPromptExtension.cs
+++ b/MagicPromptExtension.cs
@@ -65,7 +65,7 @@ public class MagicPromptExtension : Extension
         ));
         T2IParamTypes.Register<bool>(new T2IParamType(
             Name: "Generate Wildcard Seed",
-            Description: "Every time you press Generate, a new Wildcard Seed is injected into the prompt. Requires having an existing param tag like `<param[wildcardseed]:1234>` in your prompt.",
+            Description: "Every time you press Generate, a new Wildcard Seed is generated. This is extremely useful for batching images, so they can reuse cached LLM responses.",
             Default: "false",
             Group: paramGroup,
             OrderPriority: 4

--- a/MagicPromptExtension.cs
+++ b/MagicPromptExtension.cs
@@ -3,11 +3,17 @@ using SwarmUI.Core;
 using SwarmUI.Utils;
 using SwarmUI.Text2Image;
 using Newtonsoft.Json.Linq;
+using System.Security.Cryptography;
 
 namespace Hartsy.Extensions.MagicPromptExtension;
 
 public class MagicPromptExtension : Extension
 {
+    // Simple single-entry cache keyed by SHA1 hash of normalized prompt
+    private static string _cachedPromptHash;
+    private static string _cachedPrompt;
+    private static readonly object _cacheLock = new();
+
     public override void OnPreInit()
     {
         Logs.Info("MagicPromptExtension Version 2.2 Now with Vision! has started.");
@@ -31,51 +37,133 @@ public class MagicPromptExtension : Extension
     public void AddT2IParameters()
     {
         T2IParamInput.LateSpecialParameterHandlers.Add(userInput =>
+        {
+            // Get the current positive prompt early; if missing, nothing to do
+            var posPrompt = userInput.InternalSet.Get(T2IParamTypes.Prompt);
+            if (posPrompt == null)
             {
-                var posPrompt = userInput.InternalSet.Get(T2IParamTypes.Prompt);
-                if (posPrompt != null)
-                {
-                    try
-                    {
-                        // Build request for MagicPromptPhoneHome including required fields
-                        string modelId = null;
-                        try
-                        {
-                            var settingsResp = SessionSettings.GetMagicPromptSettings().GetAwaiter().GetResult();
-                            if (settingsResp != null && settingsResp["success"]?.Value<bool>() == true)
-                            {
-                                var settings = settingsResp["settings"] as JObject;
-                                modelId = settings?["model"]?.ToString();
-                            }
-                        }
-                        catch { /* ignore and leave modelId null */ }
+                return;
+            }
 
-                        JObject request = new()
-                        {
-                            ["messageContent"] = new JObject
-                            {
-                                ["text"] = posPrompt,
-                                // Leave instructions empty to let server-side default logic choose based on action
-                                ["instructions"] = ""
-                            },
-                            ["modelId"] = modelId ?? string.Empty,
-                            ["messageType"] = "Text",
-                            ["action"] = "prompt",
-                            ["session_id"] = userInput.SourceSession?.ID ?? string.Empty
-                        };
-                        var resp = LLMAPICalls.MagicPromptPhoneHome(request, userInput.SourceSession).GetAwaiter().GetResult();
-                        string newPrompt = resp?["response"]?.ToString();
-                        if (!string.IsNullOrWhiteSpace(newPrompt))
-                        {
-                            userInput.InternalSet.Set(T2IParamTypes.Prompt, newPrompt);
-                        }
-                    }
-                    catch (Exception ex)
-                    {
-                        Logs.Debug($"MagicPrompt phone home call failed: {ex.Message}");
-                    }
+            try
+            {
+                bool hasStaticTag = userInput.ExtraMeta["original_prompt"].ToString().Contains("<comment:magicpromptstatic=1>");
+
+                if (hasStaticTag)
+                {
+                    HandleCacheableRequest(posPrompt, userInput);
+                    return;
                 }
-            });
+            }
+            catch { /* ignore if missing */ }
+
+            // No static tag: proceed with normal behavior (no cache coordination needed)
+            try
+            {
+                MakeLlmRequest(posPrompt, userInput);
+            }
+            catch (Exception ex)
+            {
+                Logs.Debug($"MagicPrompt phone home call failed: {ex.Message}");
+            }
+        });
+    }
+
+    private static void HandleCacheableRequest(string posPrompt,  T2IParamInput userInput)
+    {
+        // Use hash of current prompt for caching key
+        var currentPromptHash = ComputePromptHash(posPrompt);
+
+        // Synchronize all accesses so parallel image requests share the same result
+        lock (_cacheLock)
+        {
+            // Early return if cache hit (hash matches and we have a cached prompt)
+            if (!string.IsNullOrEmpty(_cachedPromptHash) && _cachedPromptHash == currentPromptHash && !string.IsNullOrEmpty(_cachedPrompt))
+            {
+                userInput.InternalSet.Set(T2IParamTypes.Prompt, _cachedPrompt);
+                return;
+            }
+
+            // If cache exists but hash does not match, unset it now; it will be replaced after the API call below
+            if (!string.IsNullOrEmpty(_cachedPromptHash) && _cachedPromptHash != currentPromptHash)
+            {
+                _cachedPromptHash = null;
+                _cachedPrompt = "";
+            }
+
+            try
+            {
+                var llmResponse = MakeLlmRequest(posPrompt, userInput);
+                if (llmResponse != null)
+                {
+                    // Update the cache with the current hash and new prompt
+                    _cachedPromptHash = currentPromptHash;
+                    _cachedPrompt = llmResponse;
+                }
+            }
+            catch (Exception ex)
+            {
+                Logs.Debug($"MagicPrompt phone home call failed: {ex.Message}");
+            }
+
+            // Regardless of outcome, we handled the static-tag path; don't fall through to a second call
+            return;
+        }
+    }
+
+    private static string MakeLlmRequest(string posPrompt,  T2IParamInput userInput)
+    {
+        // Build request for MagicPromptPhoneHome including required fields
+        string modelId = null;
+        try
+        {
+            var settingsResp = SessionSettings.GetMagicPromptSettings().GetAwaiter().GetResult();
+            if (settingsResp != null && settingsResp["success"]?.Value<bool>() == true)
+            {
+                var settings = settingsResp["settings"] as JObject;
+                modelId = settings?["model"]?.ToString();
+            }
+        }
+        catch { /* ignore and leave modelId null */ }
+
+        JObject request = new()
+        {
+            ["messageContent"] = new JObject
+            {
+                ["text"] = posPrompt,
+                // Leave instructions empty to let server-side default logic choose based on action
+                ["instructions"] = ""
+            },
+            ["modelId"] = modelId ?? string.Empty,
+            ["messageType"] = "Text",
+            ["action"] = "prompt",
+            ["session_id"] = userInput.SourceSession?.ID ?? string.Empty
+        };
+
+        var resp = LLMAPICalls.MagicPromptPhoneHome(request, userInput.SourceSession).GetAwaiter().GetResult();
+        string llmResponse = resp?["response"]?.ToString();
+
+        if (!string.IsNullOrWhiteSpace(llmResponse))
+        {
+            userInput.InternalSet.Set(T2IParamTypes.Prompt, llmResponse);
+            return llmResponse;
+        }
+
+        return null;
+    }
+
+    private static string ComputePromptHash(string prompt)
+    {
+        if (string.IsNullOrEmpty(prompt)) return string.Empty;
+        // normalize: lowercase and strip all whitespaces
+        var normalized = new string(prompt.ToLowerInvariant().Where(c => !char.IsWhiteSpace(c)).ToArray());
+        using var sha1 = SHA1.Create();
+        var bytes = Encoding.UTF8.GetBytes(normalized);
+        var hash = sha1.ComputeHash(bytes);
+        var sb = new StringBuilder(hash.Length * 2);
+        foreach (var b in hash)
+            sb.Append(b.ToString("x2"));
+        return sb.ToString();
     }
 }
 

--- a/MagicPromptExtension.cs
+++ b/MagicPromptExtension.cs
@@ -81,6 +81,12 @@ public class MagicPromptExtension : Extension
                 return;
             }
 
+            // Parse the prompt to handle regional tags, segments, etc, and only send the core text to the LLM
+            var promptRegions = new PromptRegion(prompt);
+            var llmInputPrompt = string.IsNullOrWhiteSpace(promptRegions.GlobalPrompt)
+                ? prompt
+                : promptRegions.GlobalPrompt;
+
             try
             {
                 var useCache = userInput.InternalSet.Get(_paramUseCache);
@@ -90,9 +96,9 @@ public class MagicPromptExtension : Extension
                     ClearCache();
                 }
                 var llmResponse = useCache 
-                    ? HandleCacheableRequest(prompt, userInput)
+                    ? HandleCacheableRequest(llmInputPrompt, userInput)
                     // Use Cache is disabled: proceed with normal behavior (no cache coordination needed)
-                    : MakeLlmRequest(prompt, userInput);
+                    : MakeLlmRequest(llmInputPrompt, userInput);
 
                 // No response from LLM, fallback to original prompt
                 if (string.IsNullOrEmpty(llmResponse)) return;

--- a/MagicPromptExtension.cs
+++ b/MagicPromptExtension.cs
@@ -1,6 +1,8 @@
 using Hartsy.Extensions.MagicPromptExtension.WebAPI;
 using SwarmUI.Core;
 using SwarmUI.Utils;
+using SwarmUI.Text2Image;
+using Newtonsoft.Json.Linq;
 
 namespace Hartsy.Extensions.MagicPromptExtension;
 
@@ -23,6 +25,57 @@ public class MagicPromptExtension : Extension
     {
         // Register API endpoints so they can be used in the frontend
         MagicPromptAPI.Register();
+        AddT2IParameters();
+    }
+
+    public void AddT2IParameters()
+    {
+        T2IParamInput.LateSpecialParameterHandlers.Add(userInput =>
+            {
+                var posPrompt = userInput.InternalSet.Get(T2IParamTypes.Prompt);
+                if (posPrompt != null)
+                {
+                    try
+                    {
+                        // Build request for MagicPromptPhoneHome including required fields
+                        string modelId = null;
+                        try
+                        {
+                            var settingsResp = SessionSettings.GetMagicPromptSettings().GetAwaiter().GetResult();
+                            if (settingsResp != null && settingsResp["success"]?.Value<bool>() == true)
+                            {
+                                var settings = settingsResp["settings"] as JObject;
+                                modelId = settings?["model"]?.ToString();
+                            }
+                        }
+                        catch { /* ignore and leave modelId null */ }
+
+                        JObject request = new()
+                        {
+                            ["messageContent"] = new JObject
+                            {
+                                ["text"] = posPrompt,
+                                // Leave instructions empty to let server-side default logic choose based on action
+                                ["instructions"] = ""
+                            },
+                            ["modelId"] = modelId ?? string.Empty,
+                            ["messageType"] = "Text",
+                            ["action"] = "prompt",
+                            ["session_id"] = userInput.SourceSession?.ID ?? string.Empty
+                        };
+                        var resp = LLMAPICalls.MagicPromptPhoneHome(request, userInput.SourceSession).GetAwaiter().GetResult();
+                        string newPrompt = resp?["response"]?.ToString();
+                        if (!string.IsNullOrWhiteSpace(newPrompt))
+                        {
+                            userInput.InternalSet.Set(T2IParamTypes.Prompt, newPrompt);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Logs.Debug($"MagicPrompt phone home call failed: {ex.Message}");
+                    }
+                }
+            });
     }
 }
 


### PR DESCRIPTION
linked to https://github.com/HartsyAI/SwarmUI-MagicPromptExtension/issues/42

1) Since the user won't see the generated prompt before the genning begins, need to add stronger checks against failure messages. Like the response being too long, etc
2) ~right now, in a batch run of 9 images, the LLM is called once per image (9 times). This might be what someone wants, but most likely not. I'm unsure how to get around this with the current implementation. The way you did it in your branch of calling the LLM once then applying to the UI and then calling swarmui side-stepped this issue.~ This is fixed.

<img width="405" height="167" alt="CleanShot 2025-09-16 at 16 22 06" src="https://github.com/user-attachments/assets/b8a7c77b-0d37-4962-ac8a-14c35142d4e4" />

Added 3 checkboxes:

- Auto enable parsing prompt with LLM. If not enabled, LLM is _not_ called.
- Append original prompt to end of prompt before sending to ComfyUI. If enabled, the original parsed prompt that was handed to the MagicPromptExtension is appended to the end of the prompt, after the LLM response.
- Caching. If enabled, any subsequent identical prompts will not call LLM. This is extremely useful if you want to batch 9 images with the same prompt with only the seed changing. If you want to test it out with wildcards you must use `param[wildcardseed]` as so:

```
<param[wildcardseed]:123457>
<wc:some_wildcard_here>
your prompt is amazing.
go, you!
```

Making any change to the prompt (not including lora, comments, etc, only including things that ComfyUI will receive for the positive prompt) will invalidate the cache. Disabling "Auto Enable" checkbox will invalidate the cache.