### PR TITLE
Adding LLM model and instructions to sidebar on Generate page

### DIFF
--- a/Assets/magicprompt.js
+++ b/Assets/magicprompt.js
@@ -630,3 +630,7 @@ document.addEventListener("DOMContentLoaded", async function () {
         MP.ResponseHandler.showError('Failed to initialize MagicPrompt: ' + error.message);
     }
 });
+
+promptTabComplete.registerPrefix('mporiginal', 'Placeholder for the original prompt', (prefix) => {
+    return [];
+}, true);

--- a/Assets/settings.js
+++ b/Assets/settings.js
@@ -219,6 +219,7 @@ async function saveSettings(skipFeatureMappings = false) {
     genericRequest('SaveMagicPromptSettings', payload, (data) => {
         if (data.success) {
           console.log('Settings saved successfully');
+          updateModelListOnLeft();
         } else {
           console.error(
             `Failed to save settings: ${data.error || 'Unknown error'}`
@@ -417,6 +418,39 @@ async function fetchModels() {
     // Clear semaphore
     MP.fetchingModels = false;
     MP.fetchingModelsPromise = null;
+  }
+}
+
+function updateModelListOnLeft() {
+  try {
+    const modelSelect = document.getElementById('modelSelect');
+    const enhanceInstructions = getInstructionsForCategory('prompt');
+    const listOfModels = document.getElementById('input_mpmodelid');
+    const listOfInstructions = document.getElementById('input_mpinstructions');
+
+    if (!modelSelect || !listOfModels || !listOfInstructions) {
+      console.warn('Could not sync MP List of Models: source or destination select not found');
+      return;
+    }
+
+    listOfModels.innerHTML = '';
+    Array.from(modelSelect.options).forEach(opt => {
+      const option = new Option(opt.text, opt.value);
+      listOfModels.add(option);
+    });
+
+    listOfInstructions.innerHTML = '';
+    enhanceInstructions.forEach(instruction => {
+      const option = new Option(instruction.title, instruction.id);
+      listOfInstructions.add(option);
+    });
+
+    // Mirror current selection
+    listOfModels.value = modelSelect.value || '';
+    triggerChangeFor(listOfModels);
+    triggerChangeFor(listOfInstructions);
+  } catch (error) {
+    console.error(error.message);
   }
 }
 

--- a/MagicPromptExtension.cs
+++ b/MagicPromptExtension.cs
@@ -3,6 +3,7 @@ using SwarmUI.Core;
 using SwarmUI.Utils;
 using SwarmUI.Text2Image;
 using Newtonsoft.Json.Linq;
+using SwarmUI.Accounts;
 
 namespace Hartsy.Extensions.MagicPromptExtension;
 
@@ -13,11 +14,19 @@ public class MagicPromptExtension : Extension
     /// Storing as a single volatile reference ensures readers see a consistent pair.
     /// </summary>
     private sealed record CacheSnapshot(string NormalizedPrompt, string LlmPrompt);
+
     private static volatile CacheSnapshot _cacheSnapshot;
     private static readonly object CacheLock = new();
-    private static T2IRegisteredParam<bool> _paramAutoEnable;
-    private static T2IRegisteredParam<bool> _paramAppendOriginal;
+
+    // Cache for models/settings response to avoid duplicate API calls between GetValues lambdas
+    private static readonly object ModelsCacheLock = new();
+    private static JObject _modelsCacheResponse;
+    private static DateTime _modelsCacheTimeUtc;
+    private static readonly TimeSpan ModelsCacheTtl = TimeSpan.FromSeconds(10);
+
     private static T2IRegisteredParam<bool> _paramUseCache;
+    private static T2IRegisteredParam<string> _paramModelId;
+    private static T2IRegisteredParam<string> _paramInstructions;
 
     public override void OnPreInit()
     {
@@ -41,62 +50,77 @@ public class MagicPromptExtension : Extension
 
     private static void AddT2IParameters()
     {
-        var paramGroup = new T2IParamGroup("Magic Prompt", Toggles: true, Open: false, OrderPriority: 9);
-        _paramAutoEnable = T2IParamTypes.Register<bool>(new T2IParamType(
-            Name: "MP Auto Enable",
-            Description: "Automatically use Magic Prompt to rewrite your prompt before generation.",
-            Default: "false",
+        var paramGroup = new T2IParamGroup(
+            Name: "Magic Prompt Auto Enable",
+            Description: "Automatically use Magic Prompt to rewrite your prompt " +
+                         "before generation.",
+            Toggles: true,
+            Open: false,
+            OrderPriority: 9
+        );
+        _paramUseCache = T2IParamTypes.Register<bool>(new T2IParamType(
+            Name: "MP Use Cache",
+            Description: "Cache LLM results for static prompts to avoid repeated " +
+                         "requests to LLM.",
+            Default: "true",
             Group: paramGroup,
             OrderPriority: 1
         ));
-        _paramUseCache = T2IParamTypes.Register<bool>(new T2IParamType(
-            Name: "MP Use Cache",
-            Description: "Cache LLM results for static prompts to avoid repeated requests to LLM.",
-            Default: "true",
+        T2IParamTypes.Register<bool>(new T2IParamType(
+            Name: "MP Generate Wildcard Seed",
+            Description: "Every time you press Generate, a new Wildcard Seed is " +
+                         "generated. This is extremely useful for batching images, " +
+                         "so they can reuse cached LLM responses.",
+            Default: "false",
             Group: paramGroup,
             OrderPriority: 2
         ));
-        T2IParamTypes.Register<bool>(new T2IParamType(
-            Name: "MP Generate Wildcard Seed",
-            Description: "Every time you press Generate, a new Wildcard Seed is generated. This is extremely useful for batching images, so they can reuse cached LLM responses.",
-            Default: "false",
+        _paramModelId = T2IParamTypes.Register<string>(new T2IParamType(
+            Name: "MP Model ID",
+            Description: "Select an LLM to use for this batch",
+            Default: "loading",
+            IgnoreIf: "loading",
             Group: paramGroup,
-            OrderPriority: 3
+            OrderPriority: 3,
+            ValidateValues: false,
+            GetValues: GetModelList
         ));
-        _paramAppendOriginal = T2IParamTypes.Register<bool>(new T2IParamType(
-            Name: "MP Append Original Prompt",
-            Description: "Append the original prompt after the generated LLM prompt.",
-            Default: "false",
+        _paramInstructions = T2IParamTypes.Register<string>(new T2IParamType(
+            Name: "MP Instructions",
+            Description: "Select a prompt to use for this batch",
+            Default: "loading",
+            IgnoreIf: "loading",
             Group: paramGroup,
-            OrderPriority: 4
+            OrderPriority: 4,
+            ValidateValues: false,
+            GetValues: GetInstructionList
         ));
 
         T2IParamInput.LateSpecialParameterHandlers.Add(userInput =>
         {
-            if (userInput.GetNullable(_paramAutoEnable) is null)
+            var prompt = userInput.InternalSet.Get(T2IParamTypes.Prompt);
+            var modelId = userInput.InternalSet.Get(_paramModelId);
+            var withoutMpOriginal = prompt.Replace("<mporiginal>", "");
+
+            if (string.IsNullOrWhiteSpace(modelId))
             {
-                ClearCache();
+                Logs.Info("MagicPrompt: disabled");
+                userInput.InternalSet.Set(T2IParamTypes.Prompt, withoutMpOriginal);
                 return;
             }
 
             // Get the current positive prompt early; if missing, nothing to do
-            var prompt = userInput.InternalSet.Get(T2IParamTypes.Prompt);
             if (string.IsNullOrWhiteSpace(prompt))
             {
+                Logs.Info("MagicPrompt: empty prompt");
+                userInput.InternalSet.Set(T2IParamTypes.Prompt, withoutMpOriginal);
                 return;
             }
 
-            // If Auto Enable is not checked, clear cache and return early
-            if (!userInput.InternalSet.Get(_paramAutoEnable))
-            {
-                // Clear cache whenever Auto Enable is off
-                ClearCache();
-                return;
-            }
-
-            // Parse the prompt to handle regional tags, segments, etc, and only send the core text to the LLM
+            // Parse the prompt to handle regional tags, segments, etc, and only
+            // send the core text to the LLM
             var promptRegions = new PromptRegion(prompt);
-            var llmInputPrompt = string.IsNullOrWhiteSpace(promptRegions.GlobalPrompt)
+            var sendToLlm = string.IsNullOrWhiteSpace(promptRegions.GlobalPrompt)
                 ? prompt
                 : promptRegions.GlobalPrompt;
 
@@ -105,48 +129,52 @@ public class MagicPromptExtension : Extension
                 var useCache = userInput.InternalSet.Get(_paramUseCache);
                 if (!useCache)
                 {
+                    Logs.Info("MagicPrompt: not using cache");
+
                     // Clear cache whenever Use Cache is off
                     ClearCache();
+                } else {
+                    Logs.Info("MagicPrompt: using cache");
                 }
 
                 var llmResponse = useCache
-                    ? HandleCacheableRequest(llmInputPrompt, userInput)
-                    // Use Cache is disabled: proceed with normal behavior (no cache coordination needed)
-                    : MakeLlmRequest(llmInputPrompt, userInput);
+                    ? HandleCacheableRequest(sendToLlm, userInput)
+                    // Use Cache is disabled: proceed with normal behavior
+                    // (no cache coordination needed)
+                    : MakeLlmRequest(sendToLlm, userInput);
 
                 // No response from LLM, fallback to original prompt
-                if (string.IsNullOrEmpty(llmResponse)) return;
-
-                // Remove the core text that was sent to the LLM from the original prompt, leaving only regional tags/parts
-                if (!userInput.InternalSet.Get(_paramAppendOriginal) && !string.IsNullOrWhiteSpace(promptRegions.GlobalPrompt))
-                {
-                    prompt = prompt?.Replace(promptRegions.GlobalPrompt, string.Empty);
+                if (string.IsNullOrEmpty(llmResponse)) {
+                    Logs.Info("MagicPrompt: empty response from LLM");
+                    userInput.InternalSet.Set(T2IParamTypes.Prompt, withoutMpOriginal);
+                    return;
                 }
 
-                if (!string.IsNullOrEmpty(prompt))
-                {
-                    llmResponse = $"{llmResponse}\n{prompt}";
-                }
+                prompt = prompt.Replace(promptRegions.GlobalPrompt, llmResponse);
+                prompt = prompt.Replace("<mporiginal>", promptRegions.GlobalPrompt);
 
-                userInput.InternalSet.Set(T2IParamTypes.Prompt, llmResponse);
+                userInput.InternalSet.Set(T2IParamTypes.Prompt, prompt);
             }
             catch (Exception ex)
             {
                 Logs.Debug($"MagicPrompt phone home call failed: {ex.Message}");
+                userInput.InternalSet.Set(T2IParamTypes.Prompt, withoutMpOriginal);
             }
         });
     }
 
-    private static string HandleCacheableRequest(string prompt,  T2IParamInput userInput)
+    private static string HandleCacheableRequest(string prompt, T2IParamInput userInput)
     {
-        var normalizedPrompt = string.IsNullOrWhiteSpace(prompt) 
-            ? string.Empty 
+        var normalizedPrompt = string.IsNullOrWhiteSpace(prompt)
+            ? string.Empty
             : new string(prompt.Trim().ToLowerInvariant().Where(c => !char.IsWhiteSpace(c)).ToArray());
 
         // Fast path: double-checked locking
         // 1) Check outside the lock to avoid serializing the common case (cache hits).
-        // 2) Acquire the lock and check again to avoid a race if another thread populated the cache meanwhile.
-        // Note: Checking only once inside the lock would be correct but increases contention and latency under concurrency.
+        // 2) Acquire the lock and check again to avoid a race if another thread
+        //    populated the cache meanwhile.
+        // Note: Checking only once inside the lock would be correct but increases
+        // contention and latency under concurrency.
         var cachedPrompt = CheckCache(normalizedPrompt);
         if (!string.IsNullOrEmpty(cachedPrompt))
         {
@@ -154,11 +182,13 @@ public class MagicPromptExtension : Extension
             return cachedPrompt;
         }
 
-        // Single-lock synchronization to avoid duplicate LLM calls for the same prompt in parallel
+        // Single-lock synchronization to avoid duplicate LLM calls for the same
+        // prompt in parallel
         lock (CacheLock)
         {
             cachedPrompt = CheckCache(normalizedPrompt);
-            // Double-check cache under the lock in case another thread populated it meanwhile
+            // Double-check cache under the lock in case another thread populated
+            // it meanwhile
             if (!string.IsNullOrEmpty(cachedPrompt))
             {
                 Logs.Debug("MagicPrompt: cache hit (post-lock) for static-tag prompt.");
@@ -167,13 +197,14 @@ public class MagicPromptExtension : Extension
 
             try
             {
-                var llmResponse = MakeLlmRequest(prompt, userInput);
-                if (!string.IsNullOrEmpty(llmResponse))
+                var llmPrompt = MakeLlmRequest(prompt, userInput);
+                if (!string.IsNullOrEmpty(llmPrompt))
                 {
-                    // Atomically swap the cache snapshot so readers observe a consistent pair
-                    _cacheSnapshot = new CacheSnapshot(normalizedPrompt, llmResponse);
+                    // Atomically swap the cache snapshot so readers observe a
+                    // consistent pair
+                    _cacheSnapshot = new CacheSnapshot(normalizedPrompt, llmPrompt);
 
-                    return llmResponse;
+                    return llmPrompt;
                 }
             }
             catch (Exception ex)
@@ -189,8 +220,16 @@ public class MagicPromptExtension : Extension
     {
         // Atomic snapshot read of the last cache entry
         var snapshot = _cacheSnapshot;
-        if (snapshot is null) return null;
-        if (!string.Equals(snapshot.NormalizedPrompt, normalizedPrompt, StringComparison.Ordinal)) return null;
+        if (snapshot is null)
+        {
+            return null;
+        };
+
+        if (!string.Equals(snapshot.NormalizedPrompt, normalizedPrompt, StringComparison.Ordinal))
+        {
+            return null;
+        };
+
         return string.IsNullOrEmpty(snapshot.LlmPrompt) ? null : snapshot.LlmPrompt;
     }
 
@@ -202,39 +241,177 @@ public class MagicPromptExtension : Extension
         }
     }
 
-    private static string MakeLlmRequest(string prompt,  T2IParamInput userInput)
+    private static string MakeLlmRequest(string prompt, T2IParamInput userInput)
     {
-        // Build request for MagicPromptPhoneHome including required fields
-        string modelId = null;
-        try
-        {
-            var settingsResp = SessionSettings.GetMagicPromptSettings().GetAwaiter().GetResult();
-            if (settingsResp != null && settingsResp["success"]?.Value<bool>() == true)
-            {
-                var settings = settingsResp["settings"] as JObject;
-                modelId = settings?["model"]?.ToString();
-            }
-        }
-        catch { /* ignore and leave modelId null */ }
-
-        JObject request = new()
+        var request = new JObject
         {
             ["messageContent"] = new JObject
             {
                 ["text"] = prompt,
-                // Leave instructions empty to let server-side default logic choose based on action
-                ["instructions"] = ""
+                ["instructions"] = ResolveInstructions(userInput.InternalSet.Get(_paramInstructions))
             },
-            ["modelId"] = modelId ?? string.Empty,
+            ["modelId"] = userInput.InternalSet.Get(_paramModelId, defVal: string.Empty),
             ["messageType"] = "Text",
             ["action"] = "prompt",
             ["session_id"] = userInput.SourceSession?.ID ?? string.Empty
         };
 
-        var resp = LLMAPICalls.MagicPromptPhoneHome(request, userInput.SourceSession).GetAwaiter().GetResult();
-        var llmResponse = resp?["response"]?.ToString();
+        var resp = LLMAPICalls.MagicPromptPhoneHome(request, userInput.SourceSession)
+            .GetAwaiter()
+            .GetResult();
 
+        if (!(bool)resp?["success"])
+        {
+            return null;
+        }
+
+        var llmResponse = resp?["response"]?.ToString();
         return string.IsNullOrWhiteSpace(llmResponse) ? null : llmResponse;
     }
-}
 
+    private static string ResolveInstructions(string instructions)
+    {
+        var sessionSettings = SessionSettings.GetMagicPromptSettings()
+            .GetAwaiter()
+            .GetResult();
+        if (!sessionSettings["success"]!.Value<bool>())
+        {
+            return instructions;
+        }
+
+        var settings = sessionSettings!["settings"];
+        if (settings == null)
+        {
+            return instructions;
+        }
+
+        var instructionsObj = settings!["instructions"];
+        if (instructionsObj == null)
+        {
+            return instructions;
+        }
+
+        if (string.IsNullOrWhiteSpace(instructions))
+        {
+            return instructionsObj["prompt"]?.ToString();
+        }
+
+        // instructions currently holds the selected key
+        var customPrompt = instructionsObj["custom"][instructions]?["content"].ToString();
+        if (!string.IsNullOrWhiteSpace(customPrompt))
+        {
+            var title = instructionsObj["custom"][instructions]?["title"].ToString();
+            Logs.Info($"MagicPrompt: using custom instructions \"{title}\"");
+            return customPrompt;
+        }
+
+        var basePrompt = instructionsObj[instructions]?.ToString();
+        if (!string.IsNullOrWhiteSpace(basePrompt))
+        {
+            Logs.Info($"MagicPrompt: using base instructions \"{instructions}\"");
+            return basePrompt;
+        }
+
+        Logs.Info("MagicPrompt: using base instructions \"prompt\"");
+        return instructionsObj["prompt"]?.ToString();
+    }
+
+    private static List<string> GetModelList(Session session)
+    {
+        var defaultResponse = new List<string>{"loading///loading"};
+
+        try
+        {
+            var response = GetModelsResponseCached(session);
+            if (response?["success"]?.Value<bool>() != true)
+            {
+                return defaultResponse;
+            }
+
+            var models = response["models"] as JArray;
+            if (models == null || models.Count == 0)
+            {
+                return defaultResponse;
+            }
+
+            var list = new List<string>(models.Count);
+            foreach (var m in models)
+            {
+                var modelId = m?["model"]?.ToString();
+                var name = m?["name"]?.ToString();
+                if (string.IsNullOrWhiteSpace(modelId)) continue;
+                if (string.IsNullOrWhiteSpace(name)) name = modelId;
+                list.Add($"{modelId}///{name}");
+            }
+
+            return list.Count > 0 ? list : defaultResponse;
+        }
+        catch
+        {
+            return defaultResponse;
+        }
+    }
+
+    private static List<string> GetInstructionList(Session session)
+    {
+
+        var defaultResponse = new List<string>{"loading///loading"};
+
+        try
+        {
+            var list = new List<string>();
+            var response = GetModelsResponseCached(session);
+            var settings = response?["settings"] as JObject;
+            var instructions = settings?["instructions"] as JObject;
+
+            var prompt = instructions?["prompt"]?.ToString();
+            if (!string.IsNullOrWhiteSpace(prompt))
+            {
+                list.Add($"prompt///Enhance Prompt (Default)");
+            }
+
+            var custom = instructions?["custom"] as JObject;
+            if (custom != null)
+            {
+                foreach (var prop in custom.Properties())
+                {
+                    var title = prop.Value?["title"]?.ToString();
+                    if (!string.IsNullOrEmpty(title))
+                    {
+                        list.Add($"{prop.Name}///{title}");
+                    }
+                }
+            }
+
+            return list.Count > 0 ? list : defaultResponse;
+        }
+        catch
+        {
+            return defaultResponse;
+        }
+    }
+
+    private static JObject GetModelsResponseCached(Session session)
+    {
+        // Serve from cache if fresh
+        lock (ModelsCacheLock)
+        {
+            if (_modelsCacheResponse != null && (DateTime.UtcNow - _modelsCacheTimeUtc) < ModelsCacheTtl)
+            {
+                return _modelsCacheResponse;
+            }
+        }
+
+        var resp = LLMAPICalls.GetMagicPromptModels(session)
+            .GetAwaiter()
+            .GetResult();
+
+        lock (ModelsCacheLock)
+        {
+            _modelsCacheResponse = resp;
+            _modelsCacheTimeUtc = DateTime.UtcNow;
+        }
+
+        return resp;
+    }
+}


### PR DESCRIPTION
Improves the sidebar section:

<img width="780" height="414" alt="CleanShot 2025-09-27 at 18 05 12@2x" src="https://github.com/user-attachments/assets/b4d0f8c5-a0f0-40b4-ba4e-71bcf3a77e9b" />

* Magic Prompt Auto Enable - This switch enables or disables the automatic call to your LLM. If you generate image(s) with this on, the LLM will receive your original prompt and transform it following your specified instructions.
* MP Use Cache - When selected, and when the same original prompt is used, will reuse the same LLM response.
* MP Generate Wildcard Seed - Useful with MP Use Cache. When generating multiple images, and your prompt uses wildcards, this option will use the same wildcard seed so the generated prompt is the same. So you can use a prompt with wildcards, generate 9 images, and all 9 images would use the cached LLM response, resulting in only a single LLM call.
* MP Model ID - Allows selecting a Model, instead of having to switch in the MagicPrompt settings page.
* MP Instructions - Allows selecting an LLM instruction, instead of having to switch in the MagicPrompt settings page.

---

Adds a new `<mporiginal>`. If present, will replace with the original prompt pre-LLM. Only works if set inside a `<base>` or `<refiner>` section:

```
woman, cute, pretty, beautiful, [etc]

<base>
<mporiginal>
<refiner>
<mporiginal>
<lora:my_amazing_lora>
<segment:face,0.2,0.1> 
<segment:hands,0.1,0.1>
```

In this scenario, the string `woman, cute, pretty, beautiful, [etc]` is sent to the LLM and magically transformed into a work of literary art. However, the base and refiner models would not see the original tag-based prompt and may behave differently. Using the `<mporiginal>` would re-add `woman, cute, pretty, beautiful, [etc]` to both the base and refiner.